### PR TITLE
feat: toast context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,14 @@
 import { ResourceTable } from 'resourceTable/table'
 import { Page } from 'layout/page'
 import 'App.css';
+import { AppContextProviders } from 'common/AppContextProviders';
 
 function App() {
-  return <Page>
-    <ResourceTable />
-  </Page>;
+  return <AppContextProviders>
+    <Page>
+      <ResourceTable />
+    </Page>
+  </AppContextProviders>;
 }
 
 export default App;

--- a/src/common/AppContextProviders.tsx
+++ b/src/common/AppContextProviders.tsx
@@ -1,0 +1,25 @@
+import { FC, useContext } from "react";
+import { ToastContextProvider, toastContext } from "./toast";
+
+interface WithChildrenProps {
+  children?: React.ReactNode
+}
+
+export const AppContextProviders: FC<WithChildrenProps> = (props) => {
+  const { children } = props
+  return <ToastContextProvider>
+    <RenderWhenReady>
+      {children}
+    </RenderWhenReady>
+  </ToastContextProvider>
+}
+
+// This will not render the children until all context values are truthy
+const RenderWhenReady: FC<WithChildrenProps> = (props) => {
+  const { children } = props
+  const toastCtx = useContext(toastContext)
+  if (!toastCtx) {
+    return null
+  }
+  return <>{children}</>
+}

--- a/src/common/toast.tsx
+++ b/src/common/toast.tsx
@@ -1,8 +1,9 @@
 import { FC, createContext, useCallback, useContext, useRef, useState } from "react";
+import styled from 'styled-components'
 
 export interface ToastMessage {
-  Title: string
   message: string
+  details?: string
   level: 'info' | 'warning' | 'error'
 }
 
@@ -57,12 +58,41 @@ const useToasts = () => {
 
 export const ToastMessageEmitter: FC = () => {
   const { messages } = useContext(toastContext)
-  return <div>
-    <div>
-      {messages.reverse().map((m, i) => <div className={m.level} key={m.shown.getTime()}>
-        <div>{m.Title}</div>
-        <div>{m.message}</div>
-      </div>)}
-    </div>
-  </div>
+  return <CenterPointDiv>
+    {messages.reverse().map((m, i) => <ToastDiv className={m.level} key={m.shown.getTime()}>
+      <div>{m.message}</div>
+      {m.details && <div>{m.details}</div>}
+    </ToastDiv>)}
+  </CenterPointDiv>
 }
+
+const CenterPointDiv = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`
+const ToastDiv = styled.div`
+  width: 200px;
+  border: 2px solid;
+
+  margin: 4px 4px 0 0;
+  padding: 2px;
+  display: flex;
+  flex-direction: column;
+
+  &.info {
+    background-color: #b8b8f5;
+    border-color: #2323ac;
+  }
+  &.warning {
+    background-color: #ffd382;
+    border-color: #ffa500;
+  }
+  &.error {
+    background-color: #f58383;
+    border-color: #9c0505;
+  }
+`

--- a/src/common/toast.tsx
+++ b/src/common/toast.tsx
@@ -1,0 +1,68 @@
+import { FC, createContext, useCallback, useContext, useRef, useState } from "react";
+
+export interface ToastMessage {
+  Title: string
+  message: string
+  level: 'info' | 'warning' | 'error'
+}
+
+interface TemporalToastMessage extends ToastMessage {
+  shown: Date
+}
+
+export interface ToastContext {
+  messages: TemporalToastMessage[]
+  addMessage: (message: ToastMessage) => void
+}
+
+// @ts-expect-error
+// we will not mount the children until this context has been set
+// this will prevent the whole app from needing to do null checks
+export const toastContext = createContext<ToastContext>(null)
+
+interface ToastContextProviderProps {
+  children?: React.ReactNode
+}
+
+export const ToastContextProvider: FC<ToastContextProviderProps> = (props) => {
+  const toastContextValue = useToasts()
+
+  return <toastContext.Provider value={toastContextValue}>
+    {props.children}
+  </toastContext.Provider>
+}
+
+const useToasts = () => {
+  // ref is needed here because the state in the setTimeout closure is not guaranteed to be the latest
+  const messages = useRef<TemporalToastMessage[]>([])
+  const [, setMessageCount] = useState(0)
+
+  const removeMessage = useCallback((message: TemporalToastMessage) => {
+    messages.current = messages.current.filter(msg => msg !== message)
+    setMessageCount(messages.current.length)
+  }, [messages, setMessageCount])
+
+  const addMessage = useCallback((message: ToastMessage) => {
+    const temporalMessage = { ...message, shown: new Date() }
+    messages.current = [...messages.current, temporalMessage]
+    setMessageCount(messages.current.length)
+    setTimeout(() => removeMessage(temporalMessage), 8000)
+  }, [messages, removeMessage])
+
+  return {
+    messages: messages.current,
+    addMessage
+  }
+}
+
+export const ToastMessageEmitter: FC = () => {
+  const { messages } = useContext(toastContext)
+  return <div>
+    <div>
+      {messages.reverse().map((m, i) => <div className={m.level} key={m.shown.getTime()}>
+        <div>{m.Title}</div>
+        <div>{m.message}</div>
+      </div>)}
+    </div>
+  </div>
+}

--- a/src/layout/page.tsx
+++ b/src/layout/page.tsx
@@ -6,6 +6,7 @@ import { Header } from 'layout/header'
 import { Nav } from 'layout/nav'
 import { Footer } from 'layout/footer'
 import { MediaSizes, getMaxWidthQuery } from 'common/mediaQueries';
+import { ToastMessageEmitter } from 'common/toast';
 
 
 interface PageProps {
@@ -13,16 +14,17 @@ interface PageProps {
 }
 
 export const Page: FC<PageProps> = (props) => {
-  return <PageDiv className='App'>
-    <ErrorBoundary>
+  return <ErrorBoundary>
+    <ToastMessageEmitter />
+    <PageDiv className='App'>
       <Header />
       <Nav />
       <ContentMain>
         {props.children}
       </ContentMain>
       <Footer />
-    </ErrorBoundary>
-  </PageDiv>
+    </PageDiv>
+  </ErrorBoundary>
 }
 
 const PageDiv = styled.div`

--- a/src/resourceTable/tableRow.tsx
+++ b/src/resourceTable/tableRow.tsx
@@ -33,7 +33,8 @@ export const ResourceTableRow: FC<ResourceTableRowProps> = (props) => {
   const handleDelete = () => {
     setShowDelConfirmation(false)
     row.handleDelete()
-    props.onDeleteRow(row.id ?? '')
+      .then(() => props.onDeleteRow(row.id ?? ''))
+      .catch(() => { })
   }
 
   const editRowView = () => {


### PR DESCRIPTION
- toast messages show up and used a ref because of the setTimeout closure issue
- toasts have info, warning, error styling
- created an app context provider layer that will not mount the app until the context is defined
- fixed bug where rows would delete even if the api call "failed"